### PR TITLE
Add call to company-backend's post-completion hook on insertion

### DIFF
--- a/helm-company.el
+++ b/helm-company.el
@@ -134,6 +134,7 @@ annotations.")
     ;; `company-post-command', its post-command hook.
     (when (company-manual-begin)
       (company--insert-candidate candidate)
+      (funcall company-backend 'post-completion candidate)
       (run-hooks 'helm-company-after-completion-hooks)
       ;; for GC
       (helm-company-cleanup-post-action))))


### PR DESCRIPTION
Hi,
Great project, I use it a lot in my emacs setup. I have this change and I was 
wondering what're your thoughts on merging it?
Without this change, yasnippet integration breaks for some backends,
since the template transformation is run in the post-completion hook
for a few company backends.

Thanks