### PR TITLE
show company icons in helm-company output

### DIFF
--- a/helm-company.el
+++ b/helm-company.el
@@ -214,10 +214,12 @@ annotations.")
     str))
 
 (defun helm-company--make-display-string (candidate annotation)
-  (let ((candidate (substring-no-properties candidate)))
+  (let ((candidate (substring-no-properties candidate))
+        (icon (funcall company-format-margin-function candidate nil)))
     (if (null annotation)
-        candidate
-      (concat candidate " " (helm-company--propertize-annotation annotation)))))
+        (concat icon candidate)
+      (concat icon candidate " "
+              (helm-company--propertize-annotation annotation)))))
 
 (defun helm-company--get-annotations (candidate)
   "Return the annotation (if any) supplied for a candidate by

--- a/helm-company.el
+++ b/helm-company.el
@@ -61,6 +61,13 @@ face."
   :group 'helm-company
   :type 'boolean )
 
+(defcustom helm-company-show-icons t
+  "Show icons provided by company-backend when completing.
+
+Set it to `nil' if you want to hide the icons."
+  :group 'helm-company
+  :type 'boolean )
+
 (defcustom helm-company-initialize-pattern-with-prefix nil
   "Use the thing-at-point as the initial helm completion pattern.
 
@@ -215,7 +222,9 @@ annotations.")
 
 (defun helm-company--make-display-string (candidate annotation)
   (let ((candidate (substring-no-properties candidate))
-        (icon (funcall company-format-margin-function candidate nil)))
+        (icon (if helm-company-show-icons
+                  (funcall company-format-margin-function candidate nil)
+                "")))
     (if (null annotation)
         (concat icon candidate)
       (concat icon candidate " "


### PR DESCRIPTION
Hi,

In this PR, I enable `helm-company` to show icons of completion items, similar to what the original `company` package does.

Below are some illustration screenshots:

Current result by `helm-company`:

![helm-company-before](https://user-images.githubusercontent.com/193967/171993426-3a1f8bb7-5de8-451f-b089-932a35bcd34c.png)

After applying this PR (the icons are provided by `company`):

![helm-company](https://user-images.githubusercontent.com/193967/171993267-6d302836-d815-4d81-9cf6-636bf3e672f9.png)

Can you review the PR and consider merging it?

Thank you!